### PR TITLE
Get rid of is_a function due to Strict standards error under PHP 5.2.

### DIFF
--- a/inc/_ext/xmlrpc/_xmlrpc.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpc.inc.php
@@ -2198,7 +2198,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		function addParam($par)
 		{
 			// add check: do not add to self params which are not xmlrpcvals
-			if(is_object($par) && is_a($par, 'xmlrpcval'))
+			if(is_object($par) && $par instanceof xmlrpcval)
 			{
 				$this->params[]=$par;
 				return true;


### PR DESCRIPTION
NOTE: see that there are 38 more calls to is_a. If this commit is accepted, then the rest of changes must be done.