### PR TITLE
Fix posting via XML-RPC with PHP 7

### DIFF
--- a/inc/_ext/xmlrpc/_xmlrpcs.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpcs.inc.php
@@ -516,7 +516,7 @@ if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.'
 		* @param array $dispmap the dispatch map withd efinition of exposed services
 		* @param boolean $servicenow set to false to prevent the server from runnung upon construction
 		*/
-		function xmlrpc_server($dispMap=null, $serviceNow=true)
+		function __construct($dispMap=null, $serviceNow=true)
 		{
 			// if ZLIB is enabled, let the server by default accept compressed requests,
 			// and compress responses sent to clients that support them

--- a/inc/users/model/_usercache.class.php
+++ b/inc/users/model/_usercache.class.php
@@ -103,8 +103,8 @@ class UserCache extends DataObjectCache
 					  FROM T_users
 					 WHERE user_login = '".$DB->escape($login)."'", 0, 0, 'Get User login' ) )
 			{
-				$user_row = new User( $row );
-				$this->add( $user_row );
+				$new_user = new User( $row );
+				$this->add( $new_user );
 			}
 			else
 			{

--- a/inc/users/model/_usercache.class.php
+++ b/inc/users/model/_usercache.class.php
@@ -103,7 +103,8 @@ class UserCache extends DataObjectCache
 					  FROM T_users
 					 WHERE user_login = '".$DB->escape($login)."'", 0, 0, 'Get User login' ) )
 			{
-				$this->add( new User( $row ) );
+				$user_row = new User( $row );
+				$this->add( $user_row );
 			}
 			else
 			{


### PR DESCRIPTION
This fixes two errors that caused the XML result to be not well-formed and thus caused XML-RPC operations to be unsuccessful.