### PR TITLE
Fixed occasional empty translations

### DIFF
--- a/inc/locales/_locale.funcs.php
+++ b/inc/locales/_locale.funcs.php
@@ -120,7 +120,7 @@ if( isset( $use_l10n ) && $use_l10n )
 			if( file_exists($path) && is_readable($path) )
 			{
 				$Debuglog->add( 'T_: Loading file: '.$path, 'locale' );
-				include_once $path;
+				include $path;
 			}
 			else
 			{


### PR DESCRIPTION
In a plugin I inherited, I noticed that in the back-office, the strings weren't translated, but they are in the front-office.  I initially employed a hack, but I just looked into the cause.

It turns out that ```Plugin::register_menu``` creates a new instance of the plugin, which causes the strings to be untranslated in the second instantiation.  The reason boils down to ```include_once``` being used, which causes the ```$trans``` array to be unset (unless you declare ```$trans``` as global, which produces other problems).  The solution is to use ```include``` instead, which will let ```$trans[$messages] ``` correctly be defined between multiple calls.

An alternate solution would have been so that ```Plugin::register_menu``` wouldn't instantiate the plugin more than once, but that seems like an ad-hoc solution and wouldn't fix perhaps other problems arising from the use of ```include_once```.