### PR TITLE
PHP 7.1

### DIFF
--- a/inc/_ext/phpsvnclient/ext/Diff/Diff.php
+++ b/inc/_ext/phpsvnclient/ext/Diff/Diff.php
@@ -380,7 +380,7 @@ class Text_Diff_Op_copy extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_copy($this->final, $this->orig);
+        $reverse = new Text_Diff_Op_copy($this->final, $this->orig);
         return $reverse;
     }
 
@@ -402,7 +402,7 @@ class Text_Diff_Op_delete extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_add($this->orig);
+        $reverse = new Text_Diff_Op_add($this->orig);
         return $reverse;
     }
 
@@ -424,7 +424,7 @@ class Text_Diff_Op_add extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_delete($this->final);
+        $reverse = new Text_Diff_Op_delete($this->final);
         return $reverse;
     }
 
@@ -446,7 +446,7 @@ class Text_Diff_Op_change extends Text_Diff_Op {
 
     function &reverse()
     {
-        $reverse = &new Text_Diff_Op_change($this->final, $this->orig);
+        $reverse = new Text_Diff_Op_change($this->final, $this->orig);
         return $reverse;
     }
 

--- a/inc/_ext/phpsvnclient/ext/Diff/Diff/Engine/native.php
+++ b/inc/_ext/phpsvnclient/ext/Diff/Diff/Engine/native.php
@@ -108,7 +108,7 @@ class Text_Diff_Engine_native {
                 ++$yi;
             }
             if ($copy) {
-                $edits[] = &new Text_Diff_Op_copy($copy);
+                $edits[] = new Text_Diff_Op_copy($copy);
             }
 
             // Find deletes & adds.
@@ -123,11 +123,11 @@ class Text_Diff_Engine_native {
             }
 
             if ($delete && $add) {
-                $edits[] = &new Text_Diff_Op_change($delete, $add);
+                $edits[] = new Text_Diff_Op_change($delete, $add);
             } elseif ($delete) {
-                $edits[] = &new Text_Diff_Op_delete($delete);
+                $edits[] = new Text_Diff_Op_delete($delete);
             } elseif ($add) {
-                $edits[] = &new Text_Diff_Op_add($add);
+                $edits[] = new Text_Diff_Op_add($add);
             }
         }
 

--- a/inc/_ext/phpsvnclient/ext/Diff/Diff/Engine/xdiff.php
+++ b/inc/_ext/phpsvnclient/ext/Diff/Diff/Engine/xdiff.php
@@ -49,15 +49,15 @@ class Text_Diff_Engine_xdiff {
             }
             switch ($line[0]) {
             case ' ':
-                $edits[] = &new Text_Diff_Op_copy(array(substr($line, 1)));
+                $edits[] = new Text_Diff_Op_copy(array(substr($line, 1)));
                 break;
 
             case '+':
-                $edits[] = &new Text_Diff_Op_add(array(substr($line, 1)));
+                $edits[] = new Text_Diff_Op_add(array(substr($line, 1)));
                 break;
 
             case '-':
-                $edits[] = &new Text_Diff_Op_delete(array(substr($line, 1)));
+                $edits[] = new Text_Diff_Op_delete(array(substr($line, 1)));
                 break;
             }
         }

--- a/inc/_ext/phpsvnclient/phpsvnclient.php
+++ b/inc/_ext/phpsvnclient/phpsvnclient.php
@@ -134,11 +134,6 @@ class phpsvnclient {
     private $mime_array;
 
     public function __construct($url = 'http://phpsvnclient.googlecode.com/svn/', $user = false, $pass = false) {
-        $this->__construct($url, $user, $pass);
-        register_shutdown_function(array(&$this, '__destruct'));
-    }
-
-    public function __construct($url = 'http://phpsvnclient.googlecode.com/svn/', $user = false, $pass = false) {
         $http = & $this->_http;
         $http = new http_class;
         $http->user_agent = "phpsvnclient (http://phpsvnclient.googlecode.com/)";
@@ -148,6 +143,7 @@ class phpsvnclient {
         $this->pass = $pass;
 
         $this->actVersion = $this->getVersion();
+        register_shutdown_function(array(&$this, '__destruct'));
     }
 
     /**


### PR DESCRIPTION
Just fixes for syntax errors I encountered while linting the PHP files in PHP 7.1.  This was just the result of a little shell script:
```
for file in `find . -name '*.php'`
do
php -l $file > /dev/null
if test $? -ne 0
then
echo $file >> file
fi
done

for file in `cat file`
do
php -l $file
done
```