### PR TITLE
Fixes for PHP 7.2

### DIFF
--- a/inc/_core/_class_loader.funcs.php
+++ b/inc/_core/_class_loader.funcs.php
@@ -25,7 +25,7 @@ $map_class_path = array();
 
 /**
  * Autoload the required .class.php file when a class is accessed but not defined yet.
- * This gets hooked into spl_autoload_register (preferred) or called through __autoload.
+ * This gets hooked into spl_autoload_register.
  * Requires PHP5.
  */
 function evocms_autoload_class( $classname )
@@ -41,22 +41,10 @@ function evocms_autoload_class( $classname )
 
 
 /*
- * Use spl_autoload_register mechanism, if available (PHP>=5.1.2).
+ * Use spl_autoload_register mechanism.
  * This way a stacked set of autoload functions can be used.
  */
-if( function_exists('spl_autoload_register') )
-{
-	// spl_autoload_register( 'var_dump' );
-	spl_autoload_register( 'evocms_autoload_class' );
-}
-else
-{
-	// PHP<5.1.2: Use the fallback method.
-	function __autoload( $classname )
-	{
-		return evocms_autoload_class($classname);
-	}
-}
+spl_autoload_register( 'evocms_autoload_class' );
 
 
 /**

--- a/inc/_core/_misc.funcs.php
+++ b/inc/_core/_misc.funcs.php
@@ -732,7 +732,7 @@ function convert_chars( $content, $flag = 'html' )
 		// fp> why do we actually bother doing this:?
 		$content = preg_replace_callback(
 			'/[\x80-\xff]/',
-			create_function( '$j', 'return "&#".ord($j[0]).";";' ),
+			function( $j ) { return "&#".ord($j[0]).";";},
 			$content);
 	}
 

--- a/inc/_core/_param.funcs.php
+++ b/inc/_core/_param.funcs.php
@@ -1072,8 +1072,8 @@ function param_check_date( $var, $err_msg, $required = false, $date_format = NUL
 	}
 
 	// Convert PHP date format to regexp pattern:
-	$date_regexp = '~^'.preg_replace_callback( '~(\\\)?(\w)~', create_function( '$m', '
-		if( $m[1] == "\\\" ) return $m[2]; // escaped
+	$date_regexp = '~^'.preg_replace_callback( '~(\\\)?(\w)~', function( $m) {
+		if( $m[1] == "\\" ) return $m[2]; // escaped
 		switch( $m[2] )
 		{
 			case "d": return "([0-3]\\d)"; // day, 01-31
@@ -1093,7 +1093,7 @@ function param_check_date( $var, $err_msg, $required = false, $date_format = NUL
 			case "Y": return "(\\d{4})"; // year, XXXX
 			default:
 				return $m[0];
-		}' ), $date_format ).'$~i'; // case-insensitive?
+		} }, $date_format ).'$~i'; // case-insensitive?
 	// Allow additional spaces, e.g. "03  May 2007" when format is "d F Y":
 	$date_regexp = preg_replace( '~ +~', '\s+', $date_regexp );
 	// echo $date_format.'...'.$date_regexp;

--- a/inc/_core/_url.funcs.php
+++ b/inc/_core/_url.funcs.php
@@ -757,8 +757,8 @@ function url_absolute( $url, $base = NULL )
  */
 function make_rel_links_abs( $s, $host = NULL )
 {
-	$s = preg_replace_callback( '~(<[^>]+?)\b((?:src|href)\s*=\s*)(["\'])?([^\\3]+?)(\\3)~i', create_function( '$m', '
-		return $m[1].$m[2].$m[3].url_absolute($m[4], "'.$host.'").$m[5];' ), $s );
+	$s = preg_replace_callback( '~(<[^>]+?)\b((?:src|href)\s*=\s*)(["\'])?([^\\3]+?)(\\3)~i', function( $m ) {
+		return $m[1].$m[2].$m[3].url_absolute($m[4], "'.$host.'").$m[5];}, $s );
 	return $s;
 }
 
@@ -814,8 +814,8 @@ function is_absolute_url( $url )
  */
 function is_same_url( $a, $b, $ignore_http_protocol = FALSE )
 {
-	$a = preg_replace_callback('~%[0-9A-F]{2}~', create_function('$m', 'return strtolower($m[0]);'), $a);
-	$b = preg_replace_callback('~%[0-9A-F]{2}~', create_function('$m', 'return strtolower($m[0]);'), $b);
+	$a = preg_replace_callback('~%[0-9A-F]{2}~', function($m) { return strtolower($m[0]);}, $a);
+	$b = preg_replace_callback('~%[0-9A-F]{2}~', function($m) {return strtolower($m[0]);}, $b);
 
 	if( $ignore_http_protocol )
 	{

--- a/inc/_core/model/_diff.class.php
+++ b/inc/_core/model/_diff.class.php
@@ -332,8 +332,7 @@ class _DiffEngine {
 					continue;
 				}
 				$matches = $ymatches[$line];
-				reset( $matches );
-				while ( list( , $y ) = each( $matches ) ) {
+				foreach( $matches as $y ) {
 					if ( empty( $this->in_seq[$y] ) ) {
 						$k = $this->_lcs_pos( $y );
 						assert( $k > 0 );
@@ -341,7 +340,7 @@ class _DiffEngine {
 						break;
 					}
 				}
-				while ( list ( , $y ) = each( $matches ) ) {
+				foreach( $matches as $y ) {
 					if ( $y > $this->seq[$k -1] ) {
 						assert( $y < $this->seq[$k] );
 						// Optimization: this is a common case:

--- a/inc/_core/model/db/_db.class.php
+++ b/inc/_core/model/db/_db.class.php
@@ -389,8 +389,7 @@ class DB
 		$socket = isset( $params['socket'] ) ? $params['socket'] : ini_get('mysqli.default_socket');
 		$client_flags = isset( $params['client_flags'] ) ? $params['client_flags'] : 0;
 
-		/* Persistent connections are only available in PHP 5.3+ */
-		$this->use_persistent = isset($params['use_persistent']) ? $params['use_persistent'] : version_compare(PHP_VERSION, '5.3', '>=');
+		$this->use_persistent = isset($params['use_persistent']) ? $params['use_persistent'] : TRUE;
 
 		if( ! $this->dbhandle )
 		{ // Connect to the Database:
@@ -1333,7 +1332,7 @@ class DB
 		if( $html )
 		{ // poor man's indent
 			$sql = htmlspecialchars( $sql );
-			$sql = preg_replace_callback("~^(\s+)~m", create_function('$m', 'return str_replace(" ", "&nbsp;", $m[1]);'), $sql);
+			$sql = preg_replace_callback("~^(\s+)~m", function($m) { return str_replace(" ", "&nbsp;", $m[1]);}, $sql);
 			$sql = nl2br($sql);
 		}
 		return $sql;
@@ -1385,11 +1384,13 @@ class DB
 		{
 			$count_queries++;
 
-			$get_md5_query = create_function( '', '
+			$get_md5_query = function()
+			{
 				static $r; if( isset($r) ) return $r;
 				global $query;
 				$r = md5(serialize($query))."-".rand();
-				return $r;' );
+				return $r;
+			};
 
 			if ( $html )
 			{

--- a/inc/_core/model/db/_db.class.php
+++ b/inc/_core/model/db/_db.class.php
@@ -365,12 +365,10 @@ class DB
 			if( function_exists('dl') )
 			{
 				$mysql_ext_file = is_windows() ? 'php_mysqli.dll' : 'mysqli.so';
-				$php_errormsg = null;
-				$old_track_errors = @ini_set('track_errors', 1);
+				if (function_exists('error_clear_last')) error_clear_last(); // PHP 7+
 				$old_html_errors = @ini_set('html_errors', 0);
 				@dl( $mysql_ext_file );
-				$error_msg = $php_errormsg;
-				if( $old_track_errors !== false ) @ini_set('track_errors', $old_track_errors);
+				$error_msg = error_get_last();
 				if( $old_html_errors !== false ) @ini_set('html_errors', $old_html_errors);
 			}
 			else
@@ -399,14 +397,12 @@ class DB
 			// echo "mysqli::real_connect( $this->dbhost, $this->dbuser, $this->dbpassword, $this->dbname, port, $socket, $client_flags )";
 			// mysqli::$connect_error is tied to an established connection
 			// if the connection fails we need a different method to get the error message
-			$php_errormsg = null;
-			$old_track_errors = @ini_set('track_errors', 1);
+			if (function_exists('error_clear_last')) error_clear_last(); // PHP 7+
 			$old_html_errors = @ini_set('html_errors', 0);
 			$this->dbhandle = new mysqli();
 			@$this->dbhandle->real_connect($this->use_persistent ? 'p:'.$this->dbhost : $this->dbhost,
 				$this->dbuser, $this->dbpassword, '', $port, $socket, $client_flags );
-			$mysql_error = $php_errormsg;
-			if( $old_track_errors !== false ) @ini_set('track_errors', $old_track_errors);
+			$mysql_error = error_get_last();
 			if( $old_html_errors !== false ) @ini_set('html_errors', $old_html_errors);
 		}
 

--- a/inc/_core/model/db/_db.class.php
+++ b/inc/_core/model/db/_db.class.php
@@ -368,7 +368,7 @@ class DB
 				if (function_exists('error_clear_last')) error_clear_last(); // PHP 7+
 				$old_html_errors = @ini_set('html_errors', 0);
 				@dl( $mysql_ext_file );
-				$error_msg = error_get_last();
+				$error_msg = error_get_last()['message'];
 				if( $old_html_errors !== false ) @ini_set('html_errors', $old_html_errors);
 			}
 			else
@@ -401,7 +401,7 @@ class DB
 			$this->dbhandle = new mysqli();
 			@$this->dbhandle->real_connect($this->use_persistent ? 'p:'.$this->dbhost : $this->dbhost,
 				$this->dbuser, $this->dbpassword, '', $port, $socket, $client_flags );
-			$mysql_error = error_get_last();
+			$mysql_error = error_get_last()['message'];
 			if( $old_html_errors !== false ) @ini_set('html_errors', $old_html_errors);
 		}
 

--- a/inc/_core/model/db/_sql.class.php
+++ b/inc/_core/model/db/_sql.class.php
@@ -392,7 +392,7 @@ class SQL
 			case 'OR':
 				// Create array of key words of the search string
 				$keyword_array = explode( ' ', $search );
-				$keyword_array = array_filter( $keyword_array, create_function( '$val', 'return !empty($val);' ) );
+				$keyword_array = array_filter( $keyword_array, function($val) { return !empty($val); } );
 
 				$twhere = array();
 				// Loop on all keywords

--- a/inc/_core/model/db/_upgrade.funcs.php
+++ b/inc/_core/model/db/_upgrade.funcs.php
@@ -408,11 +408,11 @@ function db_delta( $queries, $exclude_types = array(), $execute = false )
 
 			// Sort index definitions with names to the beginning:
 			/*
-			usort( $indices, create_function( '$a, $b', '
-				if( preg_match( "~^\w+\s+[^(]~", $a["create_definition"] )
+			usort( $indices, function( $a, $b) {
+				if( preg_match( "~^\w+\s+[^(]~", $a["create_definition"] ))
 				{
 
-				}' ) );
+				} } );
 			*/
 
 

--- a/inc/_core/ui/forms/_form.class.php
+++ b/inc/_core/ui/forms/_form.class.php
@@ -1319,8 +1319,8 @@ class Form extends Widget
 
 		// Convert PHP date format to JS library date format:
 		// NOTE: when editing/extending this here, you probably also have to adjust param_check_date()!
-		$js_date_format = preg_replace_callback( '~(\\\)?(\w)~', create_function( '$m', '
-			if( $m[1] == "\\\" ) return "\\\".$m[0]; // leave escaped
+		$js_date_format = preg_replace_callback( '~(\\\)?(\w)~', function( $m ) {
+			if( $m[1] == "\\" ) return "\\".$m[0]; // leave escaped
 			switch( $m[2] )
 			{
 				case "d": return "dd"; // day, 01-31
@@ -1340,11 +1340,11 @@ class Form extends Widget
 				case "Y": return "yyyy"; // year, XXXX
 				default:
 					return $m[0];
-			}' ), $date_format );
+			} }, $date_format );
 
 		// Get max length of each date component
-		$js_date_length = preg_replace_callback( '~(\\\)?(\w)~', create_function( '$m', '
-			if( $m[1] == "\\\" ) return "\\\".$m[0]; // leave escaped
+		$js_date_length = preg_replace_callback( '~(\\\)?(\w)~', function( $m ) {
+			if( $m[1] == "\\" ) return "\\".$m[0]; // leave escaped
 			switch( $m[2] )
 			{
 				case "d": return "nn"; // day, 01-31(2)
@@ -1364,7 +1364,7 @@ class Form extends Widget
 				case "Y": return "nnnn"; // year, 1970 to 2038(4)
 				default:
 					return "_"; // (1)
-			}' ), $date_format );
+			} }, $date_format );
 
 		$field_params['type'] = 'text';
 

--- a/inc/_ext/phpsvnclient/ext/Diff/Diff/Engine/native.php
+++ b/inc/_ext/phpsvnclient/ext/Diff/Diff/Engine/native.php
@@ -193,8 +193,7 @@ class Text_Diff_Engine_native {
                     continue;
                 }
                 $matches = $ymatches[$line];
-                reset($matches);
-                while (list(, $y) = each($matches)) {
+                foreach ($matches as $y) {
                     if (empty($this->in_seq[$y])) {
                         $k = $this->_lcsPos($y);
                         assert($k > 0);
@@ -202,7 +201,7 @@ class Text_Diff_Engine_native {
                         break;
                     }
                 }
-                while (list(, $y) = each($matches)) {
+                foreach ($matches as $y) {
                     if ($y > $this->seq[$k - 1]) {
                         assert($y <= $this->seq[$k]);
                         /* Optimization: this is a common case: next match is

--- a/inc/_ext/phpwhois/whois.at.php
+++ b/inc/_ext/phpwhois/whois.at.php
@@ -61,7 +61,7 @@ class at_handler
 
 		if (isset($reg['domain']['descr']))
 			{
-			while (list($key, $val) = each($reg['domain']['descr']))
+			foreach ($reg['domain']['descr'] as $key => $val)
 				{
 				$v = trim(substr(strstr($val, ':'), 1));
 				if (strstr($val, '[organization]:'))

--- a/inc/_ext/phpwhois/whois.client.php
+++ b/inc/_ext/phpwhois/whois.client.php
@@ -331,7 +331,7 @@ class WhoisClient {
 		$output = '';
 		$pre = '';
 
-		while (list($key, $val)=each($lines)) {
+		foreach ($lines as $key => $val) {
 			$val = trim($val);
 
 			$pos=strpos(strtoupper($val),'<PRE>');
@@ -367,7 +367,7 @@ class WhoisClient {
 		$rawdata = array();
 		$null = 0;
 
-		while (list($key, $val)=each($output)) {
+		foreach ($output as $key => $val) {
 			$val=trim($val);
 			if ($val=='') {
 				if (++$null>2) continue;
@@ -524,9 +524,7 @@ class WhoisClient {
 
 	function merge_results($a1, $a2) {
 
-		reset($a2);
-
-		while (list($key, $val) = each($a2))
+		foreach ($a2 as $key => $val)
 			{
 			if (isset($a1[$key]))
 				{

--- a/inc/_ext/phpwhois/whois.gtld.fastdomain.php
+++ b/inc/_ext/phpwhois/whois.gtld.fastdomain.php
@@ -48,7 +48,7 @@ class fastdomain_handler
                   'domain.status' => 'Status:'
 		              );
 
-		while (list($key, $val) = each($data_str))
+		foreach ($data_str as $key => $val)
 			{
 			$faststr = strpos($val, ' (FAST-');
 			if ($faststr)
@@ -63,9 +63,8 @@ class fastdomain_handler
 
 		if (isset($r['domain']['nserver']))
 			{
-			reset($r['domain']['nserver']);
 			$endnserver = false;
-			while (list($key, $val) = each($r['domain']['nserver']))
+			foreach($r['domain']['nserver'] as $key => $val)
 				{
 				if ($val == '=-=-=-=')
 					unset($r['domain']['nserver'][$key]);

--- a/inc/_ext/phpwhois/whois.ip.afrinic.php
+++ b/inc/_ext/phpwhois/whois.ip.afrinic.php
@@ -60,7 +60,7 @@ class afrinic_handler
 			}
 
 		if (isset($r['owner']['remarks']) && is_array($r['owner']['remarks']))
-			while (list($key, $val) = each($r['owner']['remarks']))
+			foreach ($r['owner']['remarks'] as $key => $val)
 				{
 				$pos = strpos($val,'rwhois://');
 

--- a/inc/_ext/phpwhois/whois.ip.apnic.php
+++ b/inc/_ext/phpwhois/whois.ip.apnic.php
@@ -73,7 +73,7 @@ class apnic_handler
 
 			$r['registered'] = 'yes';
 
-			while (list($key,$val) = each($contacts))
+			foreach ($contacts as $key => $val)
 				if (isset($rb[$key]))
 					{
 					if (is_array($rb[$key]))

--- a/inc/_ext/phpwhois/whois.nu.php
+++ b/inc/_ext/phpwhois/whois.nu.php
@@ -43,7 +43,7 @@ class nu_handler
                   'handle' => 'Record ID:'
 		              );
 
-		while (list($key, $val) = each($data_str['rawdata']))
+		foreach ($data_str['rawdata'] as $key => $val)
 			{
 			$val = trim($val);
 
@@ -51,7 +51,7 @@ class nu_handler
 				{
 				if ($val == 'Domain servers in listed order:')
 					{
-					while (list($key, $val) = each($data_str['rawdata']))
+					foreach ($data_str['rawdata'] as $key => $val)
 						{
 						$val = trim($val);
 						if ($val == '')
@@ -61,9 +61,7 @@ class nu_handler
 					break;
 					}
 
-				reset($items);
-
-				while (list($field, $match) = each($items))
+				foreach($items as $field => $match)
 				if (strstr($val, $match))
 					{
 					$r['regrinfo']['domain'][$field] = trim(substr($val, strlen($match)));

--- a/inc/_ext/phpwhois/whois.parser.php
+++ b/inc/_ext/phpwhois/whois.parser.php
@@ -43,7 +43,7 @@ if (empty($blocks) || !is_array($blocks['main']))
 $r = $blocks['main'];
 $ret['registered'] = 'yes';
 
-while (list($key,$val) = each($contacts))
+foreach ($contacts as $key => $val)
 	if (isset($r[$key]))
 		{
 		if (is_array($r[$key]))
@@ -74,7 +74,7 @@ $blocks = false;
 $gkey = 'main';
 $dend = false;
 
-while (list($key,$val)=each($rawdata))
+foreach ($rawdata as $key => $val)
 	{
 	$val=trim($val);
 
@@ -341,7 +341,7 @@ if (!$items)
 $r = '';
 $disok = true;
 
-while (list($key,$val) = each($rawdata))
+foreach ($rawdata as $key => $val)
 	{
 	if (trim($val) != '')
 		{
@@ -353,9 +353,8 @@ while (list($key,$val) = each($rawdata))
 			}
 
 		$disok = false;
-		reset($items);
 
-		while (list($match, $field)=each($items))
+		foreach ($items as $key => $val)
 			{
 			$pos = strpos($val,$match);
 
@@ -413,7 +412,7 @@ function get_blocks ( $rawdata, $items, $partial_match = false, $def_block = fal
 $r = array();
 $endtag = '';
 
-while (list($key,$val) = each($rawdata))
+foreach ($rawdata as $key => $val)
 	{
 	$val = trim($val);
 	if ($val == '') continue;
@@ -463,7 +462,7 @@ while (list($key,$val) = each($rawdata))
 
 	// Block found, get data ...
 
-	while (list($key,$val) = each($rawdata))
+	foreach ($rawdata as $key => $val)
 		{
 		$val = trim($val);
 
@@ -609,16 +608,15 @@ if ($extra_items)
 	$items = $extra_items;
 	}
 
-while (list($key,$val)=each($array))
+foreach ($array as $key => $val)
 	{
 	$ok=true;
 
 	while ($ok)
 		{
-		reset($items);
 		$ok = false;
 
-		while (list($match,$field) = each($items))
+		foreach ($items as $key => $val)
 			{
 			$pos = strpos(strtolower($val),$match);
 
@@ -829,10 +827,9 @@ $ok = false;
 
 while (!$ok)
 	{
-	reset($res);
 	$ok = true;
 
-	while (list($key, $val) = each($res))
+	foreach ($res as $key => $val)
 		{
 		if ($val == '' || $key == '') continue;
 

--- a/inc/_ext/phpwhois/whois.utils.php
+++ b/inc/_ext/phpwhois/whois.utils.php
@@ -112,8 +112,7 @@ class utils extends Whois {
 
 			if (is_array($nserver))
 				{
-				reset($nserver); 
-				while (list($host, $ip) = each($nserver))
+				foreach ($nserver as $host => $ip)
 					{
 					$url = '<a href="'. str_replace('$0',$ip,$link)."\">$host</a>";
 					$out = str_replace($host, $url, $out);

--- a/inc/_ext/phpwhois/whois.zanet.php
+++ b/inc/_ext/phpwhois/whois.zanet.php
@@ -50,7 +50,7 @@ class zanet_handler
 
 		$rawdata = array();
 
-		while (list($key, $line) = each($data_str['rawdata']))
+		foreach ($data_str['rawdata'] as $key => $line)
 			{
 			if (strpos($line, ' Contact ') !== false)
 				{

--- a/inc/_ext/xmlrpc/_xmlrpc.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpc.inc.php
@@ -2614,7 +2614,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			xml_set_default_handler($parser, 'xmlrpc_dh');
 
 			// first error check: xml not well formed
-			if(!xml_parse($parser, $data, count($data)))
+			if(!xml_parse($parser, $data, strlen($data) > 0))
 			{
 				// thanks to Peter Kocks <peter.kocks@baygate.com>
 				if((xml_get_current_line_number($parser)) == 1)
@@ -3090,6 +3090,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		}
 
 		/**
+		* DEPRECATED!
 		* Reset internal pointer for xmlrpcvals of type struct.
 		* @access public
 		*/
@@ -3099,6 +3100,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		}
 
 		/**
+		* DEPRECATED!
 		* Return next member element for xmlrpcvals of type struct.
 		* @return xmlrpcval
 		* @access public
@@ -3348,7 +3350,6 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				}
 				return $arr;
 			case 'struct':
-				$xmlrpc_val->structreset();
 				// If user said so, try to rebuild php objects for specific struct vals.
 				/// @todo should we raise a warning for class not found?
 				// shall we check for proper subclass of xmlrpcval instead of
@@ -3357,7 +3358,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 					&& class_exists($xmlrpc_val->_php_class))
 				{
 					$obj = @new $xmlrpc_val->_php_class;
-					while(list($key,$value)=$xmlrpc_val->structeach())
+					foreach ($xmlrpc_val->me['struct'] as $key => $value)
 					{
 						$obj->$key = php_xmlrpc_decode($value, $options);
 					}
@@ -3366,7 +3367,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				else
 				{
 					$arr = array();
-					while(list($key,$value)=$xmlrpc_val->structeach())
+					foreach ($xmlrpc_val->me['struct'] as $key => $value)
 					{
 						$arr[$key] = php_xmlrpc_decode($value, $options);
 					}

--- a/inc/_ext/xmlrpc/_xmlrpc.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpc.inc.php
@@ -2339,7 +2339,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				}
 				// be tolerant to line endings, and extra empty lines
 				$ar = preg_split("/\r?\n/", trim(substr($data, 0, $pos)));
-				while(list(,$line) = @each($ar))
+				foreach($ar as $line)
 				{
 					// take care of multi-line headers and cookies
 					$arr = explode(':',$line,2);
@@ -2898,7 +2898,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				echo "$key => $val<br />";
 				if($key == 'array')
 				{
-					while(list($key2, $val2) = each($val))
+					foreach ($val as $key2 => $val2)
 					{
 						echo "-- $key2 => $val2<br />";
 					}
@@ -3045,7 +3045,8 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			//if (is_object($o) && (get_class($o) == 'xmlrpcval' || is_subclass_of($o, 'xmlrpcval')))
 			//{
 				reset($this->me);
-				list($typ, $val) = each($this->me);
+				$typ = key($this->me);
+				$val = current($this->me);
 				return '<value>' . $this->serializedata($typ, $val, $charset_encoding) . "</value>\n";
 			//}
 		}
@@ -3058,7 +3059,8 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			//{
 				$ar=$o->me;
 				reset($ar);
-				list($typ, $val) = each($ar);
+				$typ = key($ar);
+				$val = current($ar);
 				return '<value>' . $this->serializedata($typ, $val) . "</value>\n";
 			//}
 		}
@@ -3103,7 +3105,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		*/
 		function structeach()
 		{
-			return each($this->me['struct']);
+			return current($this->me['struct']);
 		}
 
 		// DEPRECATED! this code looks like it is very fragile and has not been fixed
@@ -3112,7 +3114,8 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		{
 			// UNSTABLE
 			reset($this->me);
-			list($a,$b)=each($this->me);
+			$a = key($this->me);
+			$b = current($this->me);
 			// contributed by I Sofer, 2001-03-24
 			// add support for nested arrays to scalarval
 			// i've created a new method here, so as to
@@ -3120,8 +3123,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 
 			if(is_array($b))
 			{
-				@reset($b);
-				while(list($id,$cont) = @each($b))
+				foreach ($b as $id => $cont)
 				{
 					$b[$id] = $cont->scalarval();
 				}
@@ -3131,13 +3133,11 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			if(is_object($b))
 			{
 				$t = get_object_vars($b);
-				@reset($t);
-				while(list($id,$cont) = @each($t))
+				foreach ($t as $id => $cont)
 				{
 					$t[$id] = $cont->scalarval();
 				}
-				@reset($t);
-				while(list($id,$cont) = @each($t))
+				foreach($t as $id => $cont)
 				{
 					@$b->$id = $cont;
 				}
@@ -3154,8 +3154,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		function scalarval()
 		{
 			reset($this->me);
-			list(,$b)=each($this->me);
-			return $b;
+			return current($this->me);
 		}
 
 		/**
@@ -3167,7 +3166,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 		function scalartyp()
 		{
 			reset($this->me);
-			list($a,)=each($this->me);
+			$a = key($this->me);
 			if($a==$GLOBALS['xmlrpcI4'])
 			{
 				$a=$GLOBALS['xmlrpcInt'];
@@ -3301,7 +3300,8 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				if (in_array('extension_api', $options))
 				{
 					reset($xmlrpc_val->me);
-					list($typ,$val) = each($xmlrpc_val->me);
+					$typ = key($xmlrpc_val->me);
+					$val = current($xmlrpc_val->me);
 					switch ($typ)
 					{
 						case 'dateTime.iso8601':
@@ -3475,7 +3475,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				{
 					$arr = array();
 					reset($php_val);
-					while(list($k,$v) = each($php_val))
+					foreach ($php_val as $k => $v)
 					{
 						$arr[$k] = php_xmlrpc_encode($v, $options);
 					}

--- a/inc/_ext/xmlrpc/_xmlrpc.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpc.inc.php
@@ -2614,7 +2614,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			xml_set_default_handler($parser, 'xmlrpc_dh');
 
 			// first error check: xml not well formed
-			if(!xml_parse($parser, $data, strlen($data) > 0))
+			if(!xml_parse($parser, $data, isset($data)))
 			{
 				// thanks to Peter Kocks <peter.kocks@baygate.com>
 				if((xml_get_current_line_number($parser)) == 1)

--- a/inc/_ext/xmlrpc/_xmlrpc_wrappers.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpc_wrappers.inc.php
@@ -465,7 +465,7 @@ if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.'
 				$allOK = 0;
 				eval($code.'$allOK=1;');
 				// alternative
-				//$xmlrpcfuncname = create_function('$m', $innercode);
+				//$xmlrpcfuncname = function($m) { eval("$innercode"); };
 
 				if(!$allOK)
 				{
@@ -680,7 +680,7 @@ if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.'
 					$allOK = 0;
 					eval($results['source'].'$allOK=1;');
 					// alternative
-					//$xmlrpcfuncname = create_function('$m', $innercode);
+					//$xmlrpcfuncname = function($m) { eval("$innercode");};
 					if($allOK)
 					{
 						return $xmlrpcfuncname;
@@ -799,7 +799,7 @@ if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.'
 					$allOK = 0;
 					eval($source.'$allOK=1;');
 					// alternative
-					//$xmlrpcfuncname = create_function('$m', $innercode);
+					//$xmlrpcfuncname = function($m) { eval($innercode); };
 					if($allOK)
 					{
 						return $xmlrpcclassname;

--- a/inc/_ext/xmlrpc/_xmlrpcs.inc.php
+++ b/inc/_ext/xmlrpc/_xmlrpcs.inc.php
@@ -393,7 +393,7 @@ if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.'
 	* NB: in fact a user defined error handler can only handle WARNING, NOTICE and USER_* errors.
 	*
 	*/
-	function _xmlrpcs_errorHandler($errcode, $errstring, $filename=null, $lineno=null, $context=null)
+	function _xmlrpcs_errorHandler($errcode, $errstring, $filename=null, $lineno=null)
 	{
 		// obey the @ protocol
 		if (error_reporting() == 0)
@@ -424,11 +424,11 @@ if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.'
 				if(is_array($GLOBALS['_xmlrpcs_prev_ehandler']))
 				{
 					// the following works both with static class methods and plain object methods as error handler
-					call_user_func_array($GLOBALS['_xmlrpcs_prev_ehandler'], array($errcode, $errstring, $filename, $lineno, $context));
+					call_user_func_array($GLOBALS['_xmlrpcs_prev_ehandler'], array($errcode, $errstring, $filename, $lineno));
 				}
 				else
 				{
-					$GLOBALS['_xmlrpcs_prev_ehandler']($errcode, $errstring, $filename, $lineno, $context);
+					$GLOBALS['_xmlrpcs_prev_ehandler']($errcode, $errstring, $filename, $lineno);
 				}
 			}
 		}

--- a/inc/collections/model/_blog.funcs.php
+++ b/inc/collections/model/_blog.funcs.php
@@ -1142,7 +1142,7 @@ function get_visibility_statuses( $format = '', $exclude = array('trash'), $chec
 
 			if( $format == 'notes-string' )
 			{	// String notes
-				$r = array_map( create_function('$v', 'return implode(" ", $v);'), $r );
+				$r = array_map( function($v) { return implode(" ", $v);}, $r );
 			}
 			break;
 

--- a/inc/items/model/_item.funcs.php
+++ b/inc/items/model/_item.funcs.php
@@ -859,7 +859,7 @@ function statuses_where_clause( $show_statuses = NULL, $dbprefix = 'post_', $req
 			$where[] = $allowed_statuses_cond;
 		}
 	}
-	elseif( count( $show_statuses ) )
+	elseif( count( (array) $show_statuses ) )
 	{ // we are not filtering so all status are allowed, add allowed statuses condition
 		$where[] = $dbprefix.'status IN ( \''.implode( '\',\'', $show_statuses ).'\' )';
 	}

--- a/inc/sessions/model/_session.class.php
+++ b/inc/sessions/model/_session.class.php
@@ -767,7 +767,7 @@ class Session
  * IMPORTANT: when modifying this, modify the following also:
  * @see session_unserialize_load_all_classes()
  *
- * @todo Once we require PHP5, we should think about using this as __autoload function.
+ * @todo Once we require PHP5, we should think about using this as an spl_autoload_register callback.
  *
  * @return boolean True, if the required class could be loaded; false, if not
  */

--- a/inc/xmlrpc/apis/_wordpress.api.php
+++ b/inc/xmlrpc/apis/_wordpress.api.php
@@ -749,6 +749,7 @@ function wp_newcategory( $m )
 	$xcontent = $m->getParam(3);
 	$contentstruct = xmlrpc_decode_recurse($xcontent);
 
+	$parent_id = !empty($contentstruct['parent_id']) ? intval($contentstruct['parent_id']) : 0;
 	$slug = strtolower($contentstruct['name']);
 	if( !empty($contentstruct['slug']) )
 	{
@@ -760,7 +761,7 @@ function wp_newcategory( $m )
 	$new_Chapter = new Chapter(NULL, $Blog->ID);
 	$new_Chapter->set('name', $contentstruct['name']);
 	$new_Chapter->set('urlname', $slug);
-	$new_Chapter->set('parent_ID', intval($contentstruct['parent_id']));
+	$new_Chapter->set('parent_ID', $parent_id);
 
 	if( !empty($contentstruct['description']) )
 	{	// Set decription

--- a/plugins/basic_antispam_plugin/_basic_antispam.plugin.php
+++ b/plugins/basic_antispam_plugin/_basic_antispam.plugin.php
@@ -327,27 +327,27 @@ class basic_antispam_plugin extends Plugin
 			return;
 		}
 
-		$data = preg_replace_callback( '~(<a\s)([^>]+)>~i', create_function( '$m', '
-				if( preg_match( \'~\brel=([\\\'"])(.*?)\1~\', $m[2], $match ) )
+		$data = preg_replace_callback( '~(<a\s)([^>]+)>~i', function( $m ) {
+				if( preg_match( '~\brel=([\\\'"])(.*?)\1~', $m[2], $match ) )
 				{ // there is already a rel attrib:
 					$rel_values = explode( " ", $match[2] );
 
-					if( ! in_array( \'nofollow\', $rel_values ) )
+					if( ! in_array( 'nofollow', $rel_values ) )
 					{
-						$rel_values[] = \'nofollow\';
+						$rel_values[] = 'nofollow';
 					}
 
 					return $m[1]
 						.preg_replace(
-							\'~\brel=([\\\'"]).*?\1~\',
-							\'rel=$1\'.implode( " ", $rel_values ).\'$1\',
+							'~\brel=([\'"]).*?\1~',
+							'rel=$1'.implode( " ", $rel_values ).'$1',
 							$m[2] )
 						.">";
 				}
 				else
 				{
-					return $m[1].$m[2].\' rel="nofollow">\';
-				}' ), $data );
+					return $m[1].$m[2].' rel="nofollow">';
+				} }, $data );
 	}
 
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ More info: http://b2evolution.net
 
 Basically, all you need is a standard [web hosting plan](http://b2evolution.net/web-hosting/top-quality-best-webhosting.php).
 
-More specifically, your web server should support PHP 5.2+, MySQL 5+ & Apache 2+ (which is very common). More info about these requirements [here](http://b2evolution.net/man/installation-upgrade/system_requirements).
+More specifically, your web server should support PHP 5.3+, MySQL 5+ & Apache 2+ (which is very common). More info about these requirements [here](http://b2evolution.net/man/installation-upgrade/system_requirements).
 
 ## Downloading
 


### PR DESCRIPTION
Replaces or removes PHP constructs that have been deprecated in PHP 7.2.  Also fixes warnings caused by behaviors that have been changed in PHP 7.2 (most notably, the first argument to count() must now be either an array or an object implementing the Countable interface).