### PR TITLE
Adding global $Settings variable

### DIFF
--- a/inc/users/views/_group.form.php
+++ b/inc/users/views/_group.form.php
@@ -24,6 +24,8 @@ global $edited_Group;
 
 global $action;
 
+global $Settings;
+
 /**
  * Display pluggable permissions
  *


### PR DESCRIPTION
@yurabakhtin I just added a missing global that was producing a constant Notice in the error logs as reported here: http://forums.b2evolution.net/b2e-6-9-3-php-notice-undefined-variable