### PR TITLE
Support Feature | Allow custom disp on validation for inskin login

### DIFF
--- a/inc/_init_login.inc.php
+++ b/inc/_init_login.inc.php
@@ -511,7 +511,8 @@ if( ! empty( $login_error ) || ( $login_required && ! is_logged_in() ) )
 			$SkinCache = & get_SkinCache();
 			$Skin = & $SkinCache->get_by_ID( $blog_skin_ID );
 			$skin = $Skin->folder;
-			$disp = 'login';
+			$disp = param( 'disp', 'string', NULL );
+			$disp = isset($disp) ? $disp : 'login';
 			// fp> We ABSOLUTELY want to recover the previous redirect_to so that after a new login attempt that may be successful,
 			// we will finally reach our intended destination. This is paramount with emails telling people to come back to the site
 			// to read a message or sth like that. They must log in first and they may enter the wrong password multiple times.


### PR DESCRIPTION
When using inskin login through a plugin this edit allows the plugin to define the `$disp` mode in the event for validation error/s.  This allows to ensure the user do not get redirected away to a different login form.


http://forums.b2evolution.net/6-9-4-inskin-login-and-error-handling