### PR TITLE
Bug | Fix validation of input_groups in dynamic types

### DIFF
--- a/inc/plugins/_plugin.funcs.php
+++ b/inc/plugins/_plugin.funcs.php
@@ -1131,6 +1131,20 @@ function autoform_validate_param_value( $param_name, $value, $meta )
 		{
 			foreach( $value as $vk => $vv )
 			{
+				// Validate input groups if they exist
+				if( isset( $mv['inputs'] ) )
+				{
+					foreach( $mv['inputs'] as $k => $v )
+					{
+						if( ! isset( $vv[$mk.$k] ) ) 
+							continue;
+
+						if( ! autoform_validate_param_value( $param_name.'['.$vk.']['.$mk.$k.']', $vv[$mk.$k], $v ) )
+						{
+							$r = false;
+						}
+					}	
+				}
 				if( ! isset( $vv[$mk] ) )
 					continue;
 


### PR DESCRIPTION
Input fields are not validated in dynamic fields for the type `input_group` (inputs)