### PR TITLE
Add missing member variable social_media_image_file_ID, fix formatting

### DIFF
--- a/inc/chapters/model/_chapter.class.php
+++ b/inc/chapters/model/_chapter.class.php
@@ -87,14 +87,19 @@ class Chapter extends DataObject
 
 	/**
 	 * Category image
- 	 */
+	 */
 	var $image_file_ID;
+
+	/**
+	 * Social media image file ID;
+	 */
+	var $social_media_image_file_ID;
 
 	/**
 	 * Constructor
 	 *
 	 * @param table Database row
- 	 * @param integer|NULL subset to use for new object
+	 * @param integer|NULL subset to use for new object
 	 */
 	function __construct( $db_row = NULL, $subset_ID = NULL )
 	{
@@ -840,7 +845,7 @@ class Chapter extends DataObject
 	{
 		switch( $parname )
 		{
- 			case 'parent_ID':
+			case 'parent_ID':
 				return $this->set_param( $parname, 'string', $parvalue, true );
 
 			case 'image_file_ID':


### PR DESCRIPTION
`Chapter::social_media_image_file_ID` is missing from the class definition so PHP blows up if it is strict.
There were extra spaces at the start of some of the lines before the tabs so I removed them.