### PR TITLE
Feature/label after input param

### DIFF
--- a/inc/_core/ui/forms/_form.class.php
+++ b/inc/_core/ui/forms/_form.class.php
@@ -3728,13 +3728,21 @@ class Form extends Widget
 	{
 		$field_params = array_merge( array(
 				'inline' => false,
+				'label_after_input' => false,
 			), $field_params );
 
 		$element = $this->get_input_element( $field_params );
 
+		if( $field_params['label_after_input'] ) {
+			$this->_common_params['element'] = $element;
+			$this->_common_params['label'] = sprintf( $this->_common_params['label'], "" );
+		}
+
 		if( $field_params['inline'] )
 		{ // Display label and input field in one line
-			$this->_common_params['label'] = sprintf( $this->_common_params['label'], $element );
+			if ( ! $field_params['label_after_input'] ) {
+				$this->_common_params['label'] = sprintf( $this->_common_params['label'], $element );
+			}
 
 			// Save the form elements:
 			$label_suffix = $this->label_suffix;
@@ -3765,7 +3773,7 @@ class Form extends Widget
 
 		$input_type = isset( $field_params['type'] ) ? $field_params['type'] : '';
 		$r = $this->begin_field( NULL, NULL, false, $input_type );
-		if( !$field_params['inline'] )
+		if( !$field_params['inline'] && !$field_params['label_after_input'])
 		{ // Append input field
 			$r .= $element;
 		}
@@ -4267,31 +4275,60 @@ class Form extends Widget
 
 		if( strlen($label) )
 		{
-			$r .= $this->labelstart;
+            if( isset($this->_common_params['label_after_input']) && $this->_common_params['label_after_input'] )
+            {
+                $r .= $this->_common_params['element'];
 
-			if( isset( $this->_common_params['clickable_label'] ) && ! $this->_common_params['clickable_label'] )
-			{	// Not set if this method is invoked by ::begin_field()
+                $r .= '<label'
+                    .( ! empty( $this->labelclass )
+                        ? ' class="'.format_to_output( $this->labelclass, 'htmlattr' ).'"'
+                        : '' )
+                    .( ! empty( $this->_common_params['id'] )
+                        ? ' for="'.format_to_output( $this->_common_params['id'], 'htmlattr' ).'"'
+                        : '' )
+                    .'>';
 
-				if( ! empty( $this->_common_params['required'] ) )
+                if( ! empty( $this->_common_params['required'] ) )
+                {
+                    $r .= '<span class="label_field_required">*</span>';
+                }
+
+                $r .= format_to_output($label, 'htmlbody');
+
+                if( empty( $this->is_lined_fields ) )
+                { // Don't print a label tag and suffix for "lined" mode:
+                    $r .= $this->label_suffix;
+
+                    $r .= '</label>';
+                }
+            }
+            else
+            {
+				$r .= $this->labelstart;
+
+				if( isset( $this->_common_params['clickable_label'] ) && ! $this->_common_params['clickable_label'] )
+				{	// Not set if this method is invoked by ::begin_field()
+
+					if( ! empty( $this->_common_params['required'] ) )
+					{
+						$r .= '<span class="label_field_required">*</span>';
+					}
+
+					$r .= format_to_output($label, 'htmlbody').$this->label_suffix;
+				}
+				else
 				{
-					$r .= '<span class="label_field_required">*</span>';
-				}
-
-				$r .= format_to_output($label, 'htmlbody').$this->label_suffix;
-			}
-			else
-			{
-				if( empty( $this->is_lined_fields ) )
-				{ // Don't print a label tag for "lined" mode:
-					$r .= '<label'
-						.( ! empty( $this->labelclass )
-							? ' class="'.format_to_output( $this->labelclass, 'htmlattr' ).'"'
-							: '' )
-						.( ! empty( $this->_common_params['id'] )
-							? ' for="'.format_to_output( $this->_common_params['id'], 'htmlattr' ).'"'
-							: '' )
-						.'>';
-				}
+					if( empty( $this->is_lined_fields ) )
+					{ // Don't print a label tag for "lined" mode:
+						$r .= '<label'
+							.( ! empty( $this->labelclass )
+								? ' class="'.format_to_output( $this->labelclass, 'htmlattr' ).'"'
+								: '' )
+							.( ! empty( $this->_common_params['id'] )
+								? ' for="'.format_to_output( $this->_common_params['id'], 'htmlattr' ).'"'
+								: '' )
+							.'>';
+					}
 
 					if( ! empty( $this->_common_params['required'] ) )
 					{
@@ -4300,15 +4337,16 @@ class Form extends Widget
 
 					$r .= format_to_output($label, 'htmlbody');
 
-				if( empty( $this->is_lined_fields ) )
-				{ // Don't print a label tag and suffix for "lined" mode:
-					$r .= $this->label_suffix;
+					if( empty( $this->is_lined_fields ) )
+					{ // Don't print a label tag and suffix for "lined" mode:
+						$r .= $this->label_suffix;
 
-					$r .= '</label>';
+						$r .= '</label>';
+					}
 				}
-			}
 
-			$r .= $this->labelend;
+				$r .= $this->labelend;
+            }
 		}
 		else
 		{ // Empty label:
@@ -4489,6 +4527,12 @@ class Form extends Widget
 			$this->_common_params['hide_label'] = $field_params['hide_label'];
 			unset( $field_params['hide_label'] );
 		}
+
+        if( isset( $field_params['label_after_input'] ) && $field_params['label_after_input'] )
+        {
+            $this->_common_params['label_after_input'] = $field_params['label_after_input'];
+            unset( $field_params['label_after_input'] );
+        }
 
 		#pre_dump( 'handle_common_params (after)', $field_params );
 	}

--- a/skins/bootstrap_blog_skin/testform.main.php
+++ b/skins/bootstrap_blog_skin/testform.main.php
@@ -1,0 +1,92 @@
+<?php
+
+if( !defined('EVO_MAIN_INIT') ) die( 'Please, do not access this page directly.' );
+
+
+global $app_version, $disp, $Collection, $Blog;
+
+if( evo_version_compare( $app_version, '6.4' ) < 0 )
+{ // Older skins (versions 2.x and above) should work on newer b2evo versions, but newer skins may not work on older b2evo versions.
+	die( 'This skin is designed for b2evolution 6.4 and above. Please <a href="http://b2evolution.net/downloads/index.html">upgrade your b2evolution</a>.' );
+}
+
+// This is the main template; it may be used to display very different things.
+// Do inits depending on current $disp:
+skin_init( $disp );
+
+
+// -------------------------- HTML HEADER INCLUDED HERE --------------------------
+skin_include( '_html_header.inc.php' );
+// -------------------------------- END OF HEADER --------------------------------
+
+
+// ---------------------------- SITE HEADER INCLUDED HERE ----------------------------
+// If site headers are enabled, they will be included here:
+siteskin_include( '_site_body_header.inc.php' );
+// ------------------------------- END OF SITE HEADER --------------------------------
+
+/**
+ * @var Message
+ */
+global $DB, $action, $Plugins, $Settings;
+
+if( !isset( $display_params ) )
+{
+	$display_params = array();
+}
+
+if( !isset( $params ) )
+{
+	$params = array();
+}
+$params = array_merge( array(
+	'form_class_thread' => 'fform',
+	'form_title' => T_('New thread').( is_admin_page() ? get_manual_link( 'messages-new-thread' ) : '' ),
+	'form_action' => NULL,
+	'form_name' => 'thread_checkchanges',
+	'form_layout' => 'compact',
+	'redirect_to' => regenerate_url( 'action', '', '', '&' ),
+	'cols' => 80,
+	'thrdtype' => param( 'thrdtype', 'string', 'discussion' ),  // alternative: individual
+	'skin_form_params' => array(),
+	'allow_select_recipients' => true,
+	'messages_list_start' => is_admin_page() ? '<div class="evo_private_messages_list">' : '',
+	'messages_list_end' => is_admin_page() ? '</div>' : '',
+), $params );
+
+$Form = new Form( $params['form_action'], $params['form_name'], 'post', $params['form_layout'] );
+
+$Form->switch_template_parts( $params['skin_form_params'] );
+
+$Form->begin_form( $params['form_class_thread'], $params['form_title'], array( 'onsubmit' => 'return check_form_thread()') );
+$Form->text_input( 'thrd_title', "", $params['cols'], T_('Subject'), '', array( 'maxlength'=> 255, 'required'=>true, 'class'=>'wide_input large' ) );
+
+// Just cleaning up a bit
+$template_rewrites = array('inputstart_checkbox' => '', 'inputend_checkbox' => '');
+foreach($template_rewrites as $key => $value)
+{
+	$$key = $Form->$key;
+	$Form->$key = $value;
+}
+$Form->checkbox_input( "check", false, "Checkbox", array('label_after_input' => true) );
+
+foreach($template_rewrites as $key => $value)
+{
+	$Form->$key = $$key;
+}
+
+// display submit button, but only if enabled
+$Form->end_form( array(
+	array( 'submit', 'actionArray[create]', T_('Send message'), 'SaveButton' )
+) );
+
+
+// ---------------------------- SITE FOOTER INCLUDED HERE ----------------------------
+// If site footers are enabled, they will be included here:
+siteskin_include( '_site_body_footer.inc.php' );
+// ------------------------------- END OF SITE FOOTER --------------------------------
+
+
+// ------------------------- HTML FOOTER INCLUDED HERE --------------------------
+skin_include( '_html_footer.inc.php' );
+// ------------------------------- END OF FOOTER --------------------------------


### PR DESCRIPTION
@fplanque I am aware you requested not to duplicate requests, so I do apologize, but this request was submitted Oct 04, 2017 on b2evolution forums and seems to have fallen unnoticed. 

The just of this PR is to support custom styled checkboxes (or radio inputs) with styling such as:

`input[type='checkbox'] + label { // rules... } input[type='checkbox']:checked + label { // rules... }`

This is not possible if the label opening tag proceeds the input element.

This is what @mgsolipa came up with.

@see http://forums.b2evolution.net/form-class-form-inputs-format-checkbox