### PR TITLE
Added setting option to break tagline into a new line, below the title...

### DIFF
--- a/inc/widgets/widgets/_coll_title.widget.php
+++ b/inc/widgets/widgets/_coll_title.widget.php
@@ -51,6 +51,12 @@ class coll_title_Widget extends ComponentWidget
 					'type' => 'checkbox',
 					'defaultvalue' => false,
 				),
+				'break_tagline' => array(
+					'label' => T_('Break tagline'),
+					'note' => T_('check to display the collection tagline in a new line, below the title.'),
+					'type' => 'checkbox',
+					'defaultvalue' => false
+				),
 			), parent::get_param_definitions( $params ) );
 
 		return $r;
@@ -118,6 +124,10 @@ class coll_title_Widget extends ComponentWidget
 							.'</a>';
 		if( $this->disp_params['add_tagline'] )
 		{ // Add a tagline after blog title
+			if( $this->disp_params['break_tagline'] )
+			{// Break tagline into a new line
+				$title .= ' <br>';
+			}
 			$title .= ' <small>'.$Blog->dget( 'tagline', 'htmlbody' ).'</small>';
 		}
 		$this->disp_title( $title );


### PR DESCRIPTION
Hi there,
I added an option in the settings area of the "Collection title" widget that allows users to display the tagline below the title instead of next to it. I found that this change improves the overall text layout when both the title and the tagline are too long for the space available in the container.
Please accept this change :-)
Thanks in advance!

P.S.: Thanks for this great software! I'm a new user and loving it :-)