### PR TITLE
extend PRIMARY KEY handling

### DIFF
--- a/inc/_core/model/db/_upgrade.funcs.php
+++ b/inc/_core/model/db/_upgrade.funcs.php
@@ -702,7 +702,7 @@ function db_delta( $queries, $exclude_types = array(), $execute = false )
 				{
 					if( ! empty( $primary_key_fields ) )
 					{
-						$column_definition .= ', DROP PRIMARY KEY';
+						$column_definition .= ', DROP PRIMARY KEY, ADD PRIMARY KEY('.$tablefield->Field.')';
 						unset( $obsolete_indices['PRIMARY'] );
 					}
 				}


### PR DESCRIPTION
fix the error:

MySQL error! / Incorrect table definition; there can be only one auto column and it must be defined as a key(Errno=1075)

Signed-off-by: Frank Kloeker <f.kloeker@telekom.de>